### PR TITLE
Configure SonarQube Cloud integration for test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,13 @@ npm run lint             # Run semistandard linter with snazzy output
 
 # Testing
 php artisan test         # Run PHPUnit tests (now available)
+php artisan test --coverage  # Run tests with coverage report
 php artisan dusk         # Run Laravel Dusk browser tests
+
+# SonarQube Analysis
+# Generate coverage report first, then run analysis
+php artisan test --coverage
+sonar-scanner -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=YOUR_TOKEN
 ```
 
 ### Database Operations
@@ -68,6 +74,7 @@ PinkieIT is a Production Management System (MES) designed for factory floor moni
 - **IoT Communication**: MQTT (Eclipse Mosquitto)
 - **Frontend**: Bootstrap 5, jQuery, Chart.js, AdminLTE 3 theme
 - **Asset Building**: Laravel Mix with Sass
+- **Code Quality**: PHPUnit with PCOV for coverage, SonarQube Cloud for analysis
 
 ### Core Architecture Patterns
 
@@ -102,4 +109,5 @@ PinkieIT is a Production Management System (MES) designed for factory floor moni
 - **Defect Tracking**: Quality control with defective product monitoring
 
 ## Updating this File
+
 If you think you need to update this file or the programmer ask to do so, update this rules to adapt to the new changes. This file is meant to be a living document that evolves with the project.

--- a/docs/SONARQUBE_SETUP.md
+++ b/docs/SONARQUBE_SETUP.md
@@ -1,0 +1,83 @@
+# SonarQube Cloud Setup Guide
+
+This guide explains how to configure SonarQube Cloud for the PinkieIT project to import and display test coverage reports.
+
+## Prerequisites
+
+- PHPUnit test coverage generation must be working (configured in `phpunit.xml`)
+- SonarQube Cloud account and project created
+- Coverage reports generated in Clover XML format at `app/laravel/coverage/clover.xml`
+
+## Configuration
+
+### 1. SonarQube Project Properties
+
+The `sonar-project.properties` file in the root directory contains the configuration for SonarQube Cloud:
+
+```properties
+# Project identification
+sonar.organization=w-pinkietech
+sonar.projectKey=w-pinkietech_pinkieit
+sonar.projectName=PinkieIT
+
+# Source and test directories
+sonar.sources=app/laravel/app
+sonar.tests=app/laravel/tests
+
+# PHP Coverage report path
+sonar.php.coverage.reportPaths=app/laravel/coverage/clover.xml
+```
+
+### 2. Generating Coverage Reports
+
+Before running SonarQube analysis, generate the coverage report:
+
+```bash
+cd app/laravel
+php artisan test --coverage
+```
+
+This will create the `coverage/clover.xml` file that SonarQube will import.
+
+### 3. Running SonarQube Analysis
+
+#### Local Analysis
+If you have SonarScanner installed locally:
+
+```bash
+# From project root
+sonar-scanner \
+  -Dsonar.host.url=https://sonarcloud.io \
+  -Dsonar.login=YOUR_SONARQUBE_TOKEN
+```
+
+#### CI/CD Integration
+The SonarQube analysis will be automatically run in CI/CD pipeline (to be configured in issue #19).
+
+## Quality Gates
+
+SonarQube Cloud will enforce quality gates based on:
+- Code coverage percentage
+- Code smells
+- Security vulnerabilities
+- Bugs
+- Technical debt
+
+## Troubleshooting
+
+### Coverage Not Showing
+1. Ensure coverage report exists: `app/laravel/coverage/clover.xml`
+2. Check that the path in `sonar.php.coverage.reportPaths` is correct
+3. Verify coverage report format is Clover XML
+
+### Files Not Analyzed
+Check the exclusions in `sonar-project.properties`:
+- Vendor directories are excluded
+- Blade templates are excluded (not PHP files)
+- Migration files are excluded
+
+## Additional Resources
+
+- [SonarQube PHP Documentation](https://docs.sonarqube.org/latest/analysis/languages/php/)
+- [SonarCloud Documentation](https://sonarcloud.io/documentation)
+- [PHPUnit Coverage Documentation](https://phpunit.de/manual/current/en/code-coverage-analysis.html)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,29 @@
+# SonarQube Cloud Configuration for PinkieIT
+
+# Project identification
+sonar.organization=w-pinkietech
+sonar.projectKey=w-pinkietech_pinkieit
+sonar.projectName=pinkieit
+sonar.projectVersion=1.0
+
+# Source code directories
+sonar.sources=app/laravel/app
+sonar.tests=app/laravel/tests
+
+# Language
+sonar.language=php
+
+# Encoding
+sonar.sourceEncoding=UTF-8
+
+# PHP Coverage
+sonar.php.coverage.reportPaths=app/laravel/coverage/clover.xml
+
+# Exclusions
+sonar.exclusions=**/*.blade.php,**/vendor/**,**/node_modules/**,**/public/**,**/storage/**,**/bootstrap/cache/**,**/database/migrations/**,**/resources/**,**/lang/**
+
+# Test exclusions
+sonar.test.exclusions=**/vendor/**,**/node_modules/**
+
+# Coverage exclusions
+sonar.coverage.exclusions=**/tests/**,**/database/**,**/config/**,**/routes/**,**/resources/**,**/public/**,**/bootstrap/**,**/storage/**


### PR DESCRIPTION
## Summary
- Configure SonarQube Cloud to import and display PHPUnit test coverage reports
- Add sonar-project.properties configuration file
- Create comprehensive setup documentation

## Changes
- **sonar-project.properties**: SonarQube configuration with PHP coverage settings
- **docs/SONARQUBE_SETUP.md**: Complete setup and troubleshooting guide
- **CLAUDE.md**: Added SonarQube commands and code quality tools to tech stack

## Test plan
- [x] Verify sonar-project.properties has correct paths
- [x] Ensure coverage report path matches PHPUnit output
- [x] Documentation includes all necessary setup steps
- [ ] Test SonarQube analysis with coverage report (requires SonarQube token)

## Related Issues
Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)